### PR TITLE
ci: run actions by default

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,5 @@
 name: Linux
 on:
-  workflow_dispatch
   push:
     branches:
     - main

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,11 +2,10 @@ name: Linux
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
-
+      - main
 
 jobs:
   Linux-GCC:
@@ -14,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [g++-7,g++-10,g++-12]
+        compiler: [g++-7, g++-10, g++-12]
 
     steps:
       - name: Checkout
@@ -33,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [clang++-8,clang++-10,clang++-14]
+        compiler: [clang++-8, clang++-10, clang++-14]
 
     steps:
       - name: Checkout

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,13 @@
 name: Linux
-on: workflow_dispatch
+on:
+  workflow_dispatch
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
 
 jobs:
   Linux-GCC:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,15 +2,15 @@ name: macOS
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   macOS-Xcode:
     name: macOS Xcode
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         xcode: [12.3, 11.7, 10.3]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,12 @@
 name: macOS
-on: workflow_dispatch
+on:
+  workflow_dispatch
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   macOS-Xcode:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,5 @@
 name: macOS
 on:
-  workflow_dispatch
   push:
     branches:
     - main

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,12 @@
 name: Windows
-on: workflow_dispatch
+on:
+  workflow_dispatch
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   Windows-VS2022-CPP20:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,5 @@
 name: Windows
 on:
-  workflow_dispatch
   push:
     branches:
     - main

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,10 +2,10 @@ name: Windows
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   Windows-VS2022-CPP20:


### PR DESCRIPTION
Hi! I think it would be better if tests were run on every pull request.

I also changed the macOS version to `macos-11` because `macos-10.15` is [deprecated](https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/).